### PR TITLE
Install packages required for thumbnail generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ ENV HTTPD_USER www-data
 
 RUN apt-get update && apt-get install -y \
   nginx php5-fpm supervisor \
-  wget unzip patch acl
+  wget unzip patch acl \
+  libav-tools imagemagick \
+  graphicsmagick zip unzip php5-gd
 
 # install h5ai and patch configuration
 RUN wget http://release.larsjung.de/h5ai/h5ai-$H5AI_VERSION.zip
@@ -20,6 +22,7 @@ RUN rm /etc/nginx/sites-enabled/default
 
 #make the cache writable
 RUN chown ${HTTPD_USER} /usr/share/h5ai/_h5ai/public/cache/
+RUN chown ${HTTPD_USER} /usr/share/h5ai/_h5ai/private/cache/
 
 # use supervisor to monitor all services
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
Thumbnail generation is entirely disabled if php5-gd isn't installed. Also install some extra tools to generate thumbnails for media files